### PR TITLE
feat(sacrament): Release 1.2.0 - Implementación completa de Módulo de Sacramentos y Corrección de Seguridad

### DIFF
--- a/src/main/java/com/sgp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sgp/common/exception/GlobalExceptionHandler.java
@@ -405,6 +405,24 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
+    //24.- Manejador para acceso a un recurso parea RolName no esta autorizado
+    @ExceptionHandler(ResourceNotAuthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotAuthorizedException(
+            ResourceNotAuthorizedException ex, HttpServletRequest request) {
+
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.FORBIDDEN.value())
+                .error("Authorization Denied")
+                .message(ex.getMessage())
+                .path(request.getRequestURI())
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+    }
+
+
+
     // 2x. Manejo genérico (Fallback) -> HTTP 500
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(

--- a/src/main/java/com/sgp/common/exception/ResourceNotAuthorizedException.java
+++ b/src/main/java/com/sgp/common/exception/ResourceNotAuthorizedException.java
@@ -1,0 +1,17 @@
+package com.sgp.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Excepción personalizada para manejar casos donde el usuario está autenticado,
+ * pero no tiene permiso (autorización) para acceder a un recurso específico o a los datos de otro usuario.
+ * Retorna HTTP 403 Forbidden.
+ */
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ResourceNotAuthorizedException extends RuntimeException {
+
+    public ResourceNotAuthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sgp/common/model/Auditable.java
+++ b/src/main/java/com/sgp/common/model/Auditable.java
@@ -1,8 +1,10 @@
 package com.sgp.common.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -31,4 +33,9 @@ public abstract class Auditable {
     /**
      * Nota: Para que @CreatedBy y @LastModifiedBy funcionen, debes tener una configuración de auditoría en Spring Boot (usando AuditorAware) que le diga a JPA cómo obtener el nombre (o ID) del usuario logueado actualmente.
      * */
+
+    // Campo de estado (Activo/Inactivo) o eliminación lógica,
+    @Setter
+    @Column(name = "is_active", nullable = false, columnDefinition = "boolean default true" )
+    private boolean isActive = true;
 }

--- a/src/main/java/com/sgp/person/model/Person.java
+++ b/src/main/java/com/sgp/person/model/Person.java
@@ -3,6 +3,7 @@ package com.sgp.person.model;
 import com.sgp.common.enums.Gender;
 import com.sgp.common.model.Auditable;
 import com.sgp.parish.model.Parish;
+import com.sgp.user.model.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -53,7 +54,17 @@ public class Person extends Auditable {
     @JoinColumn(name = "parish_id", nullable = false)
     private Parish parish;
 
-    // Campo de estado (Activo/Inactivo)
-    @Column(name = "is_active", nullable = false)
-    private boolean isActive = true;
+    // --- Relación Opcional con Usuario de Sistema ---
+    // Mapeo: UNA persona puede estar asociada a UN usuario (feligrés).
+    // Usamos LAZY para evitar bucles de carga accidental.
+    // Usamos 'unique = true' para asegurar que un User solo se asocie a una Person.
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = true) // 'user_id' será la FK
+    private User user;
+
+    // ⭐ MÉTODO CALCULADO PARA OBTENER EL NOMBRE COMPLETO ⭐
+    @Transient // Indica a JPA que este campo no debe ser persistido en la DB
+    public String getFullName() {
+        return this.firstName + " " + this.lastName;
+    }
 }

--- a/src/main/java/com/sgp/person/repository/PersonRepository.java
+++ b/src/main/java/com/sgp/person/repository/PersonRepository.java
@@ -33,4 +33,9 @@ public interface PersonRepository extends JpaRepository<Person, Long> {
 
     // Retorna todas las Personas asociadas a un ID de Parroquia específico.
     List<Person> findByParish_Id(Long parishId);
+
+    /**
+     * Busca una Persona por el ID del Usuario asociado.
+     */
+    Optional<Person> findByUser_Id(Long userId); // ⭐ NUEVO MÉTODO DE BÚSQUEDA ⭐
 }

--- a/src/main/java/com/sgp/person/service/PersonMapper.java
+++ b/src/main/java/com/sgp/person/service/PersonMapper.java
@@ -13,7 +13,9 @@ public interface PersonMapper {
     // Ignoramos el ID de la parroquia ya que será inyectado manualmente en el servicio.
     @Mapping(target = "parish", ignore = true)
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "isActive", constant = "true") // Por defecto, una nueva persona está activa
+    // Por defecto, una nueva persona está activa,
+    // ⭐ CORRECCIÓN: ELIMINAR ESTA LÍNEA, el valor por defecto en Auditable se encargará.
+    // @Mapping(target = "isActive", constant = "true")
     Person toEntity(PersonRequest request);
 
     // --- Mapeo Entity a Response (Lectura) ---

--- a/src/main/java/com/sgp/sacrament/controller/SacramentController.java
+++ b/src/main/java/com/sgp/sacrament/controller/SacramentController.java
@@ -1,0 +1,90 @@
+package com.sgp.sacrament.controller;
+
+import com.sgp.sacrament.dto.SacramentRequest;
+import com.sgp.sacrament.dto.SacramentResponse;
+import com.sgp.sacrament.service.SacramentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize; // Importación clave
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/sacraments")
+@RequiredArgsConstructor
+public class SacramentController {
+
+    private final SacramentService sacramentService;
+
+    // 1. CREAR SACRAMENTO (Registro Canónico)
+    // Acceso restringido a quienes gestionan registros (ADMIN, GESTOR).
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'GESTOR')")
+    @PostMapping
+    public ResponseEntity<SacramentResponse> createSacrament(@Valid @RequestBody SacramentRequest request) {
+        SacramentResponse response = sacramentService.createSacrament(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    // 2. OBTENER SACRAMENTO POR ID
+    // El acceso de lectura es más amplio (ADMIN, GESTOR, COORDINATOR).
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'GESTOR', 'COORDINATOR')")
+    @GetMapping("/{id}")
+    public ResponseEntity<SacramentResponse> getSacramentById(@PathVariable Long id) {
+        SacramentResponse response = sacramentService.getSacramentById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    // 3. OBTENER TODOS LOS SACRAMENTOS
+    // Lista general para la gestión.
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'GESTOR', 'COORDINATOR')")
+    @GetMapping
+    public ResponseEntity<List<SacramentResponse>> getAllSacraments() {
+        List<SacramentResponse> response = sacramentService.getAllSacraments();
+        return ResponseEntity.ok(response);
+    }
+
+    // 4. OBTENER SACRAMENTOS POR PERSONA
+    // Útil para coordinadores y gestores que consultan el historial de un feligrés.
+    // El USER simple podría acceder a *sus propios* sacramentos (requiere lógica de seguridad a nivel de servicio),
+    // pero a nivel de controlador, restringimos la búsqueda por ID a los roles internos.
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'GESTOR', 'COORDINATOR')")
+    @GetMapping("/person/{personId}")
+    public ResponseEntity<List<SacramentResponse>> getSacramentsByPersonId(@PathVariable Long personId) {
+        List<SacramentResponse> response = sacramentService.getSacramentsByPersonId(personId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 5. ACTUALIZAR SACRAMENTO
+    // Acceso restringido para modificar un registro existente (ADMIN, GESTOR).
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'GESTOR')")
+    @PutMapping("/{id}")
+    public ResponseEntity<SacramentResponse> updateSacrament(@PathVariable Long id,
+                                                             @Valid @RequestBody SacramentRequest request) {
+        SacramentResponse response = sacramentService.updateSacrament(id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 6. ELIMINAR SACRAMENTO (Eliminación Lógica)
+    // Operación muy sensible. Generalmente se restringe al máximo (ADMIN o GESTOR).
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'GESTOR')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSacrament(@PathVariable Long id) {
+        sacramentService.deleteSacrament(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * GET /api/v1/sacraments/me
+     * Obtiene todos los sacramentos de la persona asociada al usuario autenticado (el feligrés).
+     */
+    @PreAuthorize("hasAuthority('USER')") // Solo el feligrés puede ver "sus" sacramentos.
+    @GetMapping("/me")
+    public ResponseEntity<List<SacramentResponse>> getMySacraments() {
+        // Llama al nuevo método de servicio que obtiene el ID de la Persona internamente
+        List<SacramentResponse> response = sacramentService.getMySacraments();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/sgp/sacrament/dto/SacramentRequest.java
+++ b/src/main/java/com/sgp/sacrament/dto/SacramentRequest.java
@@ -1,0 +1,52 @@
+package com.sgp.sacrament.dto;
+
+import com.sgp.sacrament.enums.SacramentType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class SacramentRequest {
+
+    // --- Sacrament Fields ---
+    @NotNull(message = "El tipo de sacramento es obligatorio.")
+    private SacramentType type;
+
+    @NotNull(message = "El ID de la persona que recibe el sacramento es obligatorio.")
+    private Long personId;
+
+    @NotNull(message = "El ID de la parroquia donde se celebró es obligatorio.")
+    private Long parishId;
+
+    @PastOrPresent(message = "La fecha de celebración no puede ser futura.")
+    private LocalDate celebrationDate;
+
+    @NotBlank(message = "El número de libro es obligatorio.")
+    private String bookNumber;
+
+    @NotBlank(message = "El número de página es obligatorio.")
+    private String pageNumber;
+
+    @NotBlank(message = "El número de acta es obligatorio.")
+    private String entryNumber;
+
+    private String notes;
+
+    // --- SacramentDetail Fields ---
+    private Long officiantMinisterId; // ID del sacerdote o ministro
+
+    private Long godfather1Id; // ID del primer padrino
+
+    private Long godfather2Id; // ID del segundo padrino
+
+    private String originParishName;
+
+    private String originDioceseName;
+
+    private String fatherNameText; // Nombre del padre (si no es una Person registrada)
+
+    private String motherNameText; // Nombre de la madre (si no es una Person registrada)
+}

--- a/src/main/java/com/sgp/sacrament/dto/SacramentResponse.java
+++ b/src/main/java/com/sgp/sacrament/dto/SacramentResponse.java
@@ -1,0 +1,44 @@
+package com.sgp.sacrament.dto;
+
+import com.sgp.sacrament.enums.SacramentType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+public class SacramentResponse {
+
+    private Long id;
+    private SacramentType type;
+    private String typeDisplayName;
+
+    // Referencia a la persona receptora
+    private Long personId;
+    private String personFullName;
+
+    // Detalles del Registro
+    private LocalDate celebrationDate;
+    private String parishName;
+    private String bookNumber;
+    private String pageNumber;
+    private String entryNumber;
+    private String notes;
+
+    // Detalles Adicionales (SacramentDetail)
+    private SacramentDetailResponse detail;
+
+    @Data
+    @Builder
+    public static class SacramentDetailResponse {
+        private String officiantMinisterName;
+        private String godfather1Name;
+        private String godfather2Name;
+        private String originParishName;
+        private String originDioceseName;
+        private String fatherNameText;
+        private String motherNameText;
+    }
+}

--- a/src/main/java/com/sgp/sacrament/enums/SacramentType.java
+++ b/src/main/java/com/sgp/sacrament/enums/SacramentType.java
@@ -1,0 +1,21 @@
+package com.sgp.sacrament.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum SacramentType {
+    BAPTISM("Bautismo", 1),
+    CONFIRMATION("Confirmación", 2),
+    COMMUNION("Primera Comunión", 3),
+    MATRIMONY("Matrimonio", 4),
+    HOLY_ORDERS("Orden Sacerdotal", 5),
+    ANOINTING_OF_THE_SICK("Unción de los Enfermos", 6);
+
+    private final String displayName;
+    private final int level; // Opcional: define el orden canónico o importancia
+
+    SacramentType(String displayName, int level) {
+        this.displayName = displayName;
+        this.level = level;
+    }
+}

--- a/src/main/java/com/sgp/sacrament/model/Sacrament.java
+++ b/src/main/java/com/sgp/sacrament/model/Sacrament.java
@@ -1,0 +1,63 @@
+package com.sgp.sacrament.model;
+
+import com.sgp.common.model.Auditable;
+import com.sgp.parish.model.Parish;
+import com.sgp.person.model.Person;
+import com.sgp.sacrament.enums.SacramentType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "sacraments")
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class Sacrament extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // --- Clave al Receptor del Sacramento (Persona) ---
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "person_id", nullable = false)
+    private Person person;
+
+    // --- Tipo de Sacramento ---
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sacrament_type", nullable = false)
+    private SacramentType type;
+
+    // --- Fecha y Lugar de Celebración ---
+    @Column(name = "celebration_date", nullable = false)
+    private LocalDate celebrationDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parish_id", nullable = false)
+    private Parish parish; // La parroquia donde se celebró
+
+    @Column(name = "book_number", nullable = false)
+    private String bookNumber; // Número de libro
+
+    @Column(name = "page_number", nullable = false)
+    private String pageNumber; // Número de página
+
+    @Column(name = "entry_number", nullable = false)
+    private String entryNumber; // Número de acta
+
+    // Campo adicional para notas o observaciones canónicas
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    // ⭐ RELACIÓN ONE-TO-ONE CON DETAIL ⭐
+    // Mapeado por el campo 'sacrament' en SacramentDetail
+    @OneToOne(mappedBy = "sacrament", cascade = CascadeType.ALL, orphanRemoval = true)
+    private SacramentDetail sacramentDetail;
+
+    // Campo específico para Matrimonio, Anulación, o datos relevantes
+    private String canonicalStatus;
+}

--- a/src/main/java/com/sgp/sacrament/model/SacramentDetail.java
+++ b/src/main/java/com/sgp/sacrament/model/SacramentDetail.java
@@ -1,0 +1,62 @@
+package com.sgp.sacrament.model;
+
+import com.sgp.common.model.Auditable;
+import com.sgp.person.model.Person;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Entidad que almacena los detalles específicos de un sacramento, como padrinos,
+ * ministro oficiante y lugar de bautismo (si aplica).
+ */
+@Entity
+@Table(name = "sacrament_details")
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class SacramentDetail extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // --- Relación One-to-One con Sacrament (clave foránea) ---
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sacrament_id", nullable = false)
+    private Sacrament sacrament;
+
+    // --- Ministro Oficiante (Puede ser otra Persona) ---
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "officiant_minister_id")
+    private Person officiantMinister;
+
+    // --- Padrino 1 (Madre/Padrino de Bautismo, etc.) ---
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "godfather_1_id")
+    private Person godfather1;
+
+    // --- Padrino 2 (Padre/Madrina de Bautismo, etc.) ---
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "godfather_2_id")
+    private Person godfather2;
+
+    // --- Nombre de la Parroquia de Origen o Bautismo (si es diferente a la actual) ---
+    @Column(name = "origin_parish_name")
+    private String originParishName;
+
+    // --- Nombre de la Diócesis de Origen ---
+    @Column(name = "origin_diocese_name")
+    private String originDioceseName;
+
+    // --- Información de los Padres (Para Bautismo/Comunión) ---
+    // Usaremos los campos de Person para los padres si ya están registrados.
+    // Si no, guardaremos el nombre como texto.
+
+    @Column(name = "father_name_text")
+    private String fatherNameText;
+
+    @Column(name = "mother_name_text")
+    private String motherNameText;
+}

--- a/src/main/java/com/sgp/sacrament/repository/SacramentDetailRepository.java
+++ b/src/main/java/com/sgp/sacrament/repository/SacramentDetailRepository.java
@@ -1,0 +1,8 @@
+package com.sgp.sacrament.repository;
+
+import com.sgp.sacrament.model.SacramentDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SacramentDetailRepository extends JpaRepository<SacramentDetail, Long> {
+
+}

--- a/src/main/java/com/sgp/sacrament/repository/SacramentRepository.java
+++ b/src/main/java/com/sgp/sacrament/repository/SacramentRepository.java
@@ -1,0 +1,25 @@
+package com.sgp.sacrament.repository;
+
+import com.sgp.sacrament.model.Sacrament;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SacramentRepository extends JpaRepository<Sacrament, Long> {
+
+    /**
+     * Busca los sacramentos recibidos por una persona específica.
+     */
+    List<Sacrament> findByPerson_Id(Long personId);
+
+    /**
+     * Busca un sacramento por su número de acta, libro y página.
+     */
+    Optional<Sacrament> findByBookNumberAndPageNumberAndEntryNumber(
+            String bookNumber,
+            String pageNumber,
+            String entryNumber);
+}

--- a/src/main/java/com/sgp/sacrament/service/SacramentMapper.java
+++ b/src/main/java/com/sgp/sacrament/service/SacramentMapper.java
@@ -1,0 +1,41 @@
+package com.sgp.sacrament.service;
+
+import com.sgp.sacrament.dto.SacramentRequest;
+import com.sgp.sacrament.dto.SacramentResponse;
+import com.sgp.sacrament.model.Sacrament;
+import com.sgp.sacrament.model.SacramentDetail;
+import org.mapstruct.*;
+
+@Mapper(
+        componentModel = MappingConstants.ComponentModel.SPRING
+)
+public interface SacramentMapper {
+
+    // --- Mapeo de Request a Entidad ---
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "parish", ignore = true)
+    @Mapping(target = "person", ignore = true)
+    @Mapping(target = "canonicalStatus", ignore = true)
+    @Mapping(target = "sacramentDetail", ignore = true)
+    Sacrament toSacramentEntity(SacramentRequest request);
+
+    // --- Mapeo de Entidad a Response ---
+
+    // ⭐ CORRECCIÓN 1: Especificar la fuente del ID ⭐
+    @Mapping(source = "sacrament.id", target = "id")
+
+    @Mapping(source = "sacrament.type.displayName", target = "typeDisplayName")
+    @Mapping(source = "sacrament.person.id", target = "personId")
+    @Mapping(source = "sacrament.person.fullName", target = "personFullName")
+    @Mapping(source = "sacrament.parish.name", target = "parishName")
+    @Mapping(source = "detail", target = "detail")
+    SacramentResponse toResponse(Sacrament sacrament, SacramentDetail detail);
+
+    // Mapeo del detalle (sub-DTO)
+    @Mapping(source = "officiantMinister.fullName", target = "officiantMinisterName")
+
+    // ⭐ CORRECCIÓN 2: Usar getFullName() para Padrinos ⭐
+    @Mapping(source = "godfather1.fullName", target = "godfather1Name")
+    @Mapping(source = "godfather2.fullName", target = "godfather2Name")
+    SacramentResponse.SacramentDetailResponse toDetailResponse(SacramentDetail detail);
+}

--- a/src/main/java/com/sgp/sacrament/service/SacramentService.java
+++ b/src/main/java/com/sgp/sacrament/service/SacramentService.java
@@ -1,0 +1,32 @@
+package com.sgp.sacrament.service;
+
+import com.sgp.sacrament.dto.SacramentRequest;
+import com.sgp.sacrament.dto.SacramentResponse;
+
+import java.util.List;
+
+public interface SacramentService {
+
+    /** Crea un nuevo registro de sacramento y sus detalles. */
+    SacramentResponse createSacrament(SacramentRequest request);
+
+    /** Obtiene un sacramento por su ID. */
+    SacramentResponse getSacramentById(Long id);
+
+    /** * Obtiene todos los sacramentos recibidos por la persona asociada al usuario autenticado.
+     */
+    List<SacramentResponse> getMySacraments(); // ⭐ NUEVO MÉTODO ⭐
+
+    /** Obtiene todos los sacramentos registrados. */
+    List<SacramentResponse> getAllSacraments();
+
+    /** Obtiene todos los sacramentos recibidos por una persona específica. */
+    List<SacramentResponse> getSacramentsByPersonId(Long personId);
+
+    /** Actualiza un registro de sacramento y sus detalles. */
+    SacramentResponse updateSacrament(Long id, SacramentRequest request);
+
+    /** Elimina (lógicamente) un registro de sacramento. */
+    void deleteSacrament(Long id);
+}
+

--- a/src/main/java/com/sgp/sacrament/service/SacramentServiceImpl.java
+++ b/src/main/java/com/sgp/sacrament/service/SacramentServiceImpl.java
@@ -1,0 +1,259 @@
+package com.sgp.sacrament.service;
+
+import com.sgp.common.exception.ResourceConflictException;
+import com.sgp.common.exception.ResourceNotAuthorizedException;
+import com.sgp.common.exception.ResourceNotFoundException;
+import com.sgp.parish.model.Parish;
+import com.sgp.parish.repository.ParishRepository;
+import com.sgp.person.model.Person;
+import com.sgp.person.repository.PersonRepository;
+import com.sgp.sacrament.dto.SacramentRequest;
+import com.sgp.sacrament.dto.SacramentResponse;
+import com.sgp.sacrament.model.Sacrament;
+import com.sgp.sacrament.model.SacramentDetail;
+import com.sgp.sacrament.repository.SacramentRepository;
+import com.sgp.sacrament.repository.SacramentDetailRepository; // Asumo que crearemos este
+import com.sgp.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SacramentServiceImpl implements SacramentService {
+
+    private final SacramentRepository sacramentRepository;
+    private final SacramentDetailRepository sacramentDetailRepository; // Lo necesitaremos para guardar detalles
+    private final PersonRepository personRepository;
+    private final ParishRepository parishRepository;
+    private final SacramentMapper sacramentMapper;
+
+    private static final String RESOURCE_SACRAMENT = "Sacramento";
+    private static final String RESOURCE_PERSON = "Persona";
+    private static final String RESOURCE_PARISH = "Parroquia";
+
+    // --- Métodos de Ayuda para Búsqueda y Validación ---
+
+    private Sacrament findSacramentById(Long id) {
+        return sacramentRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_SACRAMENT, "id", id));
+    }
+
+    // Busca una entidad Person (ministro, padrino)
+    private Person findPersonById(Long id, String role) {
+        if (id == null) return null; // Si el ID es nulo, la persona es opcional
+        return personRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_PERSON, role + " ID", id));
+    }
+
+    // Busca la entidad Parish
+    private Parish findParishById(Long id) {
+        return parishRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(RESOURCE_PARISH, "ID", id));
+    }
+
+    // Valida la unicidad del Acta
+    private void validateUniqueActa(String book, String page, String entry) {
+        if (sacramentRepository.findByBookNumberAndPageNumberAndEntryNumber(book, page, entry).isPresent()) {
+            throw new ResourceConflictException(RESOURCE_SACRAMENT, "Acta",
+                    String.format("Libro: %s, Página: %s, Acta: %s", book, page, entry));
+        }
+    }
+
+    // --- CREATE ---
+    @Override
+    @Transactional
+    public SacramentResponse createSacrament(SacramentRequest request) {
+        // 1. Validar unicidad del Acta
+        validateUniqueActa(request.getBookNumber(), request.getPageNumber(), request.getEntryNumber());
+
+        // 2. Buscar y validar entidades relacionadas
+        Person recipient = findPersonById(request.getPersonId(), "Receptora");
+        Parish parish = findParishById(request.getParishId());
+
+        Person minister = findPersonById(request.getOfficiantMinisterId(), "Ministro");
+        Person godfather1 = findPersonById(request.getGodfather1Id(), "Padrino 1");
+        Person godfather2 = findPersonById(request.getGodfather2Id(), "Padrino 2");
+
+        // 3. Mapear y asignar
+        Sacrament sacrament = sacramentMapper.toSacramentEntity(request);
+        sacrament.setPerson(recipient);
+        sacrament.setParish(parish);
+
+        // 4. Guardar Sacrament
+        Sacrament savedSacrament = sacramentRepository.save(sacrament);
+
+        // 5. Crear y guardar SacramentDetail
+        SacramentDetail detail = new SacramentDetail();
+        detail.setSacrament(savedSacrament);
+        detail.setOfficiantMinister(minister);
+        detail.setGodfather1(godfather1);
+        detail.setGodfather2(godfather2);
+
+        detail.setOriginParishName(request.getOriginParishName());
+        detail.setOriginDioceseName(request.getOriginDioceseName());
+        detail.setFatherNameText(request.getFatherNameText());
+        detail.setMotherNameText(request.getMotherNameText());
+
+        SacramentDetail savedDetail = sacramentDetailRepository.save(detail);
+        savedSacrament.setSacramentDetail(savedDetail); // Enlazar el detalle de vuelta al sacramento
+
+        // 6. Responder
+        return sacramentMapper.toResponse(savedSacrament, savedDetail);
+    }
+
+    // --- READ (Single) ---
+    @Override
+    @Transactional(readOnly = true)
+    public SacramentResponse getSacramentById(Long id) {
+        Sacrament sacrament = findSacramentById(id);
+        // Cargar el detalle explícitamente si no está cargado por defecto (Lazy)
+        SacramentDetail detail = sacrament.getSacramentDetail();
+        return sacramentMapper.toResponse(sacrament, detail);
+    }
+
+    // --- READ (All) ---
+    @Override
+    @Transactional(readOnly = true)
+    public List<SacramentResponse> getAllSacraments() {
+        return sacramentRepository.findAll().stream()
+                .map(s -> sacramentMapper.toResponse(s, s.getSacramentDetail()))
+                .collect(Collectors.toList());
+    }
+
+    // --- READ (By Person) ---
+    @Override
+    @Transactional(readOnly = true)
+    public List<SacramentResponse> getSacramentsByPersonId(Long personId) {
+        return sacramentRepository.findByPerson_Id(personId).stream()
+                .map(s -> sacramentMapper.toResponse(s, s.getSacramentDetail()))
+                .collect(Collectors.toList());
+    }
+
+    // --- UPDATE ---
+    @Override
+    @Transactional
+    public SacramentResponse updateSacrament(Long id, SacramentRequest request) {
+        Sacrament existingSacrament = findSacramentById(id);
+        SacramentDetail existingDetail = existingSacrament.getSacramentDetail();
+
+        // 1. Validar unicidad si los números de Acta han cambiado
+        boolean actaChanged = !existingSacrament.getBookNumber().equals(request.getBookNumber()) ||
+                !existingSacrament.getPageNumber().equals(request.getPageNumber()) ||
+                !existingSacrament.getEntryNumber().equals(request.getEntryNumber());
+
+        if (actaChanged) {
+            sacramentRepository.findByBookNumberAndPageNumberAndEntryNumber(
+                            request.getBookNumber(), request.getPageNumber(), request.getEntryNumber())
+                    .filter(s -> !s.getId().equals(id)) // Asegurar que no sea este mismo registro
+                    .ifPresent(s -> {
+                        throw new ResourceConflictException(RESOURCE_SACRAMENT, "Acta", "ya existe");
+                    });
+        }
+
+        // 2. Buscar y validar entidades relacionadas para actualizar
+        Person recipient = findPersonById(request.getPersonId(), "Receptora");
+        Parish parish = findParishById(request.getParishId());
+
+        Person minister = findPersonById(request.getOfficiantMinisterId(), "Ministro");
+        Person godfather1 = findPersonById(request.getGodfather1Id(), "Padrino 1");
+        Person godfather2 = findPersonById(request.getGodfather2Id(), "Padrino 2");
+
+        // 3. Actualizar Sacrament (Usando el mapper para los campos básicos, si es posible)
+        // Ya que MapStruct no soporta el mapeo de Request a Entity sobre un existente fácilmente con IDs
+        // haremos la actualización manual de los campos.
+        existingSacrament.setType(request.getType());
+        existingSacrament.setCelebrationDate(request.getCelebrationDate());
+        existingSacrament.setBookNumber(request.getBookNumber());
+        existingSacrament.setPageNumber(request.getPageNumber());
+        existingSacrament.setEntryNumber(request.getEntryNumber());
+        existingSacrament.setNotes(request.getNotes());
+
+        // Actualizar relaciones si han cambiado
+        if (!existingSacrament.getPerson().getId().equals(recipient.getId())) {
+            existingSacrament.setPerson(recipient);
+        }
+        if (!existingSacrament.getParish().getId().equals(parish.getId())) {
+            existingSacrament.setParish(parish);
+        }
+
+        // 4. Actualizar SacramentDetail
+        existingDetail.setOfficiantMinister(minister);
+        existingDetail.setGodfather1(godfather1);
+        existingDetail.setGodfather2(godfather2);
+        existingDetail.setOriginParishName(request.getOriginParishName());
+        existingDetail.setOriginDioceseName(request.getOriginDioceseName());
+        existingDetail.setFatherNameText(request.getFatherNameText());
+        existingDetail.setMotherNameText(request.getMotherNameText());
+
+        // Guardar ambos (Detail se guardará por la cascada si es @OneToOne(cascade=ALL) en Sacrament,
+        // pero lo haremos explícitamente si lo creamos)
+        // Por ahora, confiamos en que Spring Data JPA gestione la persistencia del Detail
+        // o que la salvación explícita en el detail repo sea necesaria.
+        // Si tienes una relación bidireccional adecuada, solo guardar el Sacrament es suficiente.
+        Sacrament updatedSacrament = sacramentRepository.save(existingSacrament);
+
+        // 5. Responder
+        return sacramentMapper.toResponse(updatedSacrament, existingDetail);
+    }
+
+    // --- DELETE (Lógico) ---
+    @Override
+    @Transactional
+    public void deleteSacrament(Long id) {
+        Sacrament sacrament = findSacramentById(id);
+
+        // ⭐ IMPLEMENTACIÓN DE ELIMINACIÓN LÓGICA ⭐
+        if (!sacrament.isActive()) {
+            // Opcional: lanzar una excepción si ya está inactivo
+            throw new ResourceConflictException(RESOURCE_SACRAMENT, "estado", "ya está inactivo");
+        }
+        // Nota: Si SacramentDetail también debe ser marcado,
+        // Pero dado que es un registro canónico, el principal es el Sacrament.
+        // 1. Eliminación Lógica del Sacramento principal
+        sacrament.setActive(false);
+        sacramentRepository.save(sacrament);
+
+        // 2. Eliminación Lógica del Detalle asociado (CRÍTICO)
+        // El 'detail' debe cargarse junto con el sacramento, o buscarse por separado.
+        SacramentDetail detail = sacrament.getSacramentDetail();
+        if (detail != null && detail.isActive()) {
+            detail.setActive(false);
+            sacramentDetailRepository.save(detail);
+        }
+    }
+
+    // --- READ (My Sacraments) ---
+    @Override
+    @Transactional(readOnly = true)
+    public List<SacramentResponse> getMySacraments() {
+        // 1. Obtener el User ID del contexto de seguridad
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        // El 'principal' es el objeto UserDetails (que en tu caso es la entidad User)
+        // pero necesitamos el ID del User para buscar la Person.
+
+        Long userId ;
+        if (auth.getPrincipal() instanceof UserDetails) {
+            // Asumiendo que tu entidad User implementa UserDetails y tiene el ID
+            userId = ((User) auth.getPrincipal()).getId();
+        } else {
+            // En caso de que no sea un usuario autenticado (debería ser filtrado por @PreAuthorize)
+            throw new ResourceNotAuthorizedException("Acceso no autorizado al recurso personal.");
+        }
+
+        // 2. Buscar la Persona asociada a este User ID
+        Person person = personRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Persona", "Usuario ID", userId));
+
+        // 3. Llamar a la función existente con el ID de la Persona canónica
+        return getSacramentsByPersonId(person.getId());
+    }
+
+}

--- a/src/main/java/com/sgp/security/config/AuthExceptionHandler.java
+++ b/src/main/java/com/sgp/security/config/AuthExceptionHandler.java
@@ -50,7 +50,20 @@ public class AuthExceptionHandler implements AuthenticationEntryPoint, AccessDen
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         // Se añade request.getRequestURI() para el path
-        buildResponse(response, HttpStatus.UNAUTHORIZED, "Unauthorized", "Acceso denegado. Se requiere autenticacion (Token JWT).", request.getRequestURI());
+        // ⭐ CAMBIO CLAVE: Usar el mensaje de la excepción recibida ⭐
+        // Si el mensaje de la excepción es nulo o vacío, usar el mensaje genérico.
+        String errorMessage = authException.getMessage();
+        if (errorMessage == null || errorMessage.trim().isEmpty()) {
+            errorMessage = "Acceso denegado. Se requiere autenticacion (Token JWT).";
+        }
+
+        buildResponse(
+                response,
+                HttpStatus.UNAUTHORIZED,
+                "Unauthorized",
+                errorMessage, // ⬅️ AHORA USAMOS EL MENSAJE DE LA EXCEPCIÓN
+                request.getRequestURI()
+        );
     }
 
     // Maneja 403 Forbidden (Token válido pero rol insuficiente)

--- a/src/main/java/com/sgp/security/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sgp/security/config/jwt/JwtAuthenticationFilter.java
@@ -1,18 +1,26 @@
 package com.sgp.security.config.jwt;
+import com.sgp.security.config.AuthExceptionHandler;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.security.SignatureException;
 
 @Component // Para que Spring lo gestione como un Bean
 @RequiredArgsConstructor
@@ -20,6 +28,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService; // Lo definimos en SecurityConfig
+    // 💡 NECESITAMOS LA INSTANCIA DEL MANEJADOR DE ERRORES PARA DELEGAR
+    private final AuthExceptionHandler authExceptionHandler; // ⬅️ INYECTAR
 
     @Override
     protected void doFilterInternal(
@@ -41,36 +51,64 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 3. Extraer el token (eliminar "Bearer ")
         jwt = authHeader.substring(7);
-        userEmail = jwtService.extractUsername(jwt); // Obtener el email del token
 
-        // 4. Si el email existe y el usuario no está ya autenticado
-        if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+        // ⭐ Bloque TRY-CATCH para manejar las excepciones de JWT ⭐
+        try {
+            userEmail = jwtService.extractUsername(jwt); // Obtener el email del token, porque al estar en un Bloque TryCatch Puede lanzar ExpiredJwtException, SignatureException, etc.
 
-            // Cargar los detalles del usuario desde la base de datos (PostgreSQL)
-            UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
+            // 4. Si el email existe y el usuario no está ya autenticado
+            if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                // Cargar los detalles del usuario desde la base de datos (PostgreSQL)
+                UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
 
-            // 5. Validar el token y el usuario
-            if (jwtService.isTokenValid(jwt, userDetails)) {
+                // 5. Validar el token y el usuario
+                if (jwtService.isTokenValid(jwt, userDetails)) {
 
-                // Si es válido, crear un objeto de autenticación
-                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null, // La contraseña se pasa como null en autenticación de token
-                        userDetails.getAuthorities()
-                );
+                    // Si es válido, crear un objeto de autenticación
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null, // La contraseña se pasa como null en autenticación de token
+                            userDetails.getAuthorities()
+                    );
 
-                // Establecer detalles de la petición
-                authToken.setDetails(
-                        new WebAuthenticationDetailsSource().buildDetails(request)
-                );
+                    // Establecer detalles de la petición
+                    authToken.setDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request)
+                    );
 
-                // 6. Almacenar la autenticación en el Contexto de Seguridad
-                // El usuario está autenticado y Spring Security puede autorizar las peticiones
-                SecurityContextHolder.getContext().setAuthentication(authToken);
+                    // 6. Almacenar la autenticación en el Contexto de Seguridad
+                    // El usuario está autenticado y Spring Security puede autorizar las peticiones
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
             }
-        }
+            // Continuar con el siguiente filtro en la cadena si todo va bien
+            filterChain.doFilter(request, response);
 
-        // Continuar con el siguiente filtro en la cadena
-        filterChain.doFilter(request, response);
+        }catch (ExpiredJwtException ex){
+            // 💡 Token expirado: DELEGAR el manejo al AuthExceptionHandler (401)
+            // Lanza una excepción de Spring Security que el EntryPoint puede manejar,
+            // O DELEGA la escritura de la respuesta directamente.
+
+            // Usaremos el AuthExceptionHandler para escribir la respuesta 401:
+            authExceptionHandler.commence(request, response, new AuthenticationServiceException("JWT token has expired.", ex));
+            // IMPORTANTE: NO llamar a filterChain.doFilter(request, response) después de manejar el error.
+
+        } catch (JwtException e) {
+            // 💡 Otra excepción JWT (Ej. SignatureException, MalformedJwtException):
+            // DELEGAR el manejo al AuthExceptionHandler (401)
+            authExceptionHandler.commence(request, response, new AuthenticationServiceException("Invalid JWT token structure or signature.", e));
+            // IMPORTANTE: NO llamar a filterChain.doFilter(request, response) después de manejar el error.
+
+        } catch (UsernameNotFoundException e) {
+            // 💡 Usuario no encontrado (aunque el token sea válido):
+            // DELEGAR el manejo al AuthExceptionHandler (401)
+            authExceptionHandler.commence(request, response, new UsernameNotFoundException("User not found from valid JWT token.", e));
+            // IMPORTANTE: NO llamar a filterChain.doFilter(request, response) después de manejar el error.
+        }
+        catch (Exception e) {
+            // Captura cualquier otra excepción no esperada de la cadena JWT (Good Practice)
+            AuthenticationException authException = new AuthenticationServiceException("Error inesperado en el procesamiento del token JWT.", e);
+            authExceptionHandler.commence(request, response, authException);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ spring.datasource.username=sgp_user
 spring.datasource.password=sgp_password
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect#No es necesario s seleccionado por default
 
 # CONFIGURACION DE REDIS (Usando el servicio 'redis' en el puerto 6379)
 spring.data.redis.host=localhost


### PR DESCRIPTION
**Módulo a Producción:** Lanzamiento de la versión estable del módulo de Gestión Canónica de Sacramentos.

Esta actualización promueve a `main` todas las funcionalidades y correcciones desarrolladas en `develop` desde el último despliegue.

### 🚀 Nuevas Funcionalidades (Features)

* **Módulo de Sacramentos:** Implementación completa de CRUD (Creación, Lectura, Actualización y Eliminación Lógica) para registros de Sacramentos y Detalles Canónicos.
* **Seguridad por Rol:** Se establecieron las directivas `@PreAuthorize` para todos los endpoints del módulo de Sacramentos, restringiendo el acceso según los roles (`ADMIN`, `GESTOR`, `COORDINATOR`, `USER`).
* **Endpoint Personal `/me`:** Se agregó el endpoint `/api/v1/sacraments/me` exclusivo para el rol `USER`, permitiendo a los feligreses consultar su propio historial de sacramentos.

### 🐛 Correcciones Críticas (Bug Fixes)

* **Manejo de Expiración de JWT:** Se implementó el manejo explícito de `io.jsonwebtoken.ExpiredJwtException` y otras fallas de JWT (`SignatureException`, `MalformedJwtException`) dentro de `JwtAuthenticationFilter`.
* **Mejora en Respuestas de Error:** El `AuthExceptionHandler` fue modificado para devolver mensajes de error 401 específicos (ej. "El token JWT ha expirado") en lugar de un mensaje genérico, mejorando la experiencia del cliente.